### PR TITLE
docs(claude): add VSIX development rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,41 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 7. **Check branch status before pushing** - Verify the remote tracking branch still exists. If a PR was merged/deleted, create a new branch from main instead
 8. **WPF for all UI** - All UI must be implemented using WPF (XAML/C#). No web-based technologies (HTML, JavaScript, WebView)
 
+### VSIX Development Rules
+
+**Solution & Project Structure:**
+- SLNX solution files only (no legacy .sln)
+- Solution naming: `CodingWithCalvin.<ProjectFolder>`
+- Primary project naming: `CodingWithCalvin.<ProjectFolder>`
+- Additional project naming: `CodingWithCalvin.<ProjectFolder>.<Classifier>`
+
+**Build Configuration:**
+- Configurations: Debug and Release
+- Platform: AnyCPU
+- Build Tools: Latest 17.* release
+- VSSDK: Latest 17.* release
+
+**Target Frameworks:**
+- Main VSIX project: .NET Framework 4.8
+- Library projects: .NET Standard 2.0 (may use SDK-style project format)
+
+**VSIX Manifest:**
+- Version range: `[17.0,19.0)` — supports VS 2022 through VS 2026
+- Architectures: AMD64 and ARM64
+- Prerequisites: List Community edition only (captures Pro/Enterprise)
+
+**CI/CD:**
+- Build workflow: Automated build on push/PR
+- Publish workflow: Automated marketplace publishing
+- Marketplace config: `publish.manifest.json` for automated publishing
+
+**Development Environment:**
+- Required extension: Extensibility Essentials 2022
+- Helper library: VsixCommunity Toolkit
+
+**Documentation:**
+- README should be exciting and use emojis
+
 ---
 
 ### GitHub CLI Commands


### PR DESCRIPTION
## Summary
- Add VSIX Development Rules section to CLAUDE.md
- Documents standards for solution structure, build configuration, target frameworks, manifest settings, CI/CD, and development environment