### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,4 @@ jobs:
       extension-name: GitRanger
       display-name: 'Git Ranger'
       marketplace-id: CodingWithCalvin.VS-GitRanger
-      description: 'A visually stunning Git management extension for Visual Studio 2022/2026'
-      hashtags: '#git'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly