### PR TITLE
feat(blame): add inline blame display mode option

### DIFF
--- a/src/CodingWithCalvin.GitRanger/Editor/BlameAdornment/BlameAdornment.cs
+++ b/src/CodingWithCalvin.GitRanger/Editor/BlameAdornment/BlameAdornment.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using CodingWithCalvin.GitRanger.Core.Models;
 using CodingWithCalvin.GitRanger.Options;
@@ -35,6 +36,7 @@ internal sealed class BlameAdornment
     private IReadOnlyList<BlameLineInfo> _blameData = Array.Empty<BlameLineInfo>();
     private string? _currentFilePath;
     private bool _isLoading;
+    private int _activeLineNumber = -1;
 
     /// <summary>
     /// Creates a new blame adornment for the given text view.
@@ -60,6 +62,9 @@ internal sealed class BlameAdornment
         // Subscribe to events
         _view.LayoutChanged += OnLayoutChanged;
         _view.Closed += OnViewClosed;
+        _view.Caret.PositionChanged += OnCaretPositionChanged;
+        _view.VisualElement.MouseMove += OnMouseMove;
+        _view.VisualElement.MouseLeave += OnMouseLeave;
         _blameService.BlameLoaded += OnBlameLoaded;
         GeneralOptions.Saved += OnOptionsSaved;
 
@@ -71,8 +76,61 @@ internal sealed class BlameAdornment
     {
         _view.LayoutChanged -= OnLayoutChanged;
         _view.Closed -= OnViewClosed;
+        _view.Caret.PositionChanged -= OnCaretPositionChanged;
+        _view.VisualElement.MouseMove -= OnMouseMove;
+        _view.VisualElement.MouseLeave -= OnMouseLeave;
         _blameService.BlameLoaded -= OnBlameLoaded;
         GeneralOptions.Saved -= OnOptionsSaved;
+    }
+
+    private void OnCaretPositionChanged(object sender, CaretPositionChangedEventArgs e)
+    {
+        var options = GeneralOptions.Instance;
+        if (options == null || !options.EnableInlineBlame || options.InlineBlameDisplayMode != InlineBlameMode.CurrentLine)
+            return;
+
+        var caretLineNumber = _view.TextSnapshot.GetLineNumberFromPosition(
+            _view.Caret.Position.BufferPosition.Position) + 1;
+
+        if (caretLineNumber == _activeLineNumber)
+            return;
+
+        _activeLineNumber = caretLineNumber;
+        ClearAdornments();
+        UpdateAdornments();
+    }
+
+    private void OnMouseMove(object sender, MouseEventArgs e)
+    {
+        var options = GeneralOptions.Instance;
+        if (options == null || !options.EnableInlineBlame || options.InlineBlameDisplayMode != InlineBlameMode.Hover)
+            return;
+
+        var position = e.GetPosition(_view.VisualElement);
+        var viewportPoint = new Point(position.X + _view.ViewportLeft, position.Y + _view.ViewportTop);
+
+        var hoveredLine = _view.TextViewLines.GetTextViewLineContainingYCoordinate(viewportPoint.Y);
+        if (hoveredLine == null)
+            return;
+
+        var lineNumber = _view.TextSnapshot.GetLineNumberFromPosition(hoveredLine.Start.Position) + 1;
+
+        if (lineNumber == _activeLineNumber)
+            return;
+
+        _activeLineNumber = lineNumber;
+        ClearAdornments();
+        UpdateAdornments();
+    }
+
+    private void OnMouseLeave(object sender, MouseEventArgs e)
+    {
+        var options = GeneralOptions.Instance;
+        if (options == null || !options.EnableInlineBlame || options.InlineBlameDisplayMode != InlineBlameMode.Hover)
+            return;
+
+        _activeLineNumber = -1;
+        ClearAdornments();
     }
 
     private void OnOptionsSaved(GeneralOptions options)
@@ -173,6 +231,12 @@ internal sealed class BlameAdornment
         if (_isLoading || _blameData.Count == 0)
             return;
 
+        if (options.InlineBlameDisplayMode == InlineBlameMode.CurrentLine)
+        {
+            _activeLineNumber = _view.TextSnapshot.GetLineNumberFromPosition(
+                _view.Caret.Position.BufferPosition.Position) + 1;
+        }
+
         var viewportTop = _view.ViewportTop;
         var viewportBottom = _view.ViewportBottom;
 
@@ -182,6 +246,10 @@ internal sealed class BlameAdornment
                 continue;
 
             var lineNumber = _view.TextSnapshot.GetLineNumberFromPosition(line.Start.Position) + 1;
+
+            if (options.InlineBlameDisplayMode != InlineBlameMode.Always && lineNumber != _activeLineNumber)
+                continue;
+
             var blameInfo = _blameData.FirstOrDefault(b => b.LineNumber == lineNumber);
             if (blameInfo == null)
                 continue;

--- a/src/CodingWithCalvin.GitRanger/Options/GeneralOptions.cs
+++ b/src/CodingWithCalvin.GitRanger/Options/GeneralOptions.cs
@@ -85,10 +85,10 @@ namespace CodingWithCalvin.GitRanger.Options
         public bool CompactMode { get; set; } = false;
 
         [Category("Display")]
-        [DisplayName("Show On Hover Only")]
-        [Description("Only show detailed blame information on mouse hover.")]
-        [DefaultValue(false)]
-        public bool ShowOnHoverOnly { get; set; } = false;
+        [DisplayName("Inline Blame Display Mode")]
+        [Description("Controls when inline blame is shown: Always (all lines), CurrentLine (caret line only), or Hover (mouse hover only).")]
+        [DefaultValue(InlineBlameMode.Always)]
+        public InlineBlameMode InlineBlameDisplayMode { get; set; } = InlineBlameMode.Always;
 
         // Gutter Settings
         [Category("Gutter")]
@@ -134,6 +134,27 @@ namespace CodingWithCalvin.GitRanger.Options
         [Description("Controls output pane verbosity. None=disabled, Error=failures only, Info=key events, Verbose=detailed tracing.")]
         [DefaultValue(LogLevel.Error)]
         public LogLevel LogLevel { get; set; } = LogLevel.Error;
+    }
+
+    /// <summary>
+    /// Controls when inline blame annotations are displayed.
+    /// </summary>
+    public enum InlineBlameMode
+    {
+        /// <summary>
+        /// Show inline blame on all visible lines.
+        /// </summary>
+        Always,
+
+        /// <summary>
+        /// Show inline blame only on the current caret line.
+        /// </summary>
+        CurrentLine,
+
+        /// <summary>
+        /// Show inline blame only when the mouse hovers over a line.
+        /// </summary>
+        Hover
     }
 
     /// <summary>

--- a/src/CodingWithCalvin.GitRanger/Options/GeneralOptionsPage.cs
+++ b/src/CodingWithCalvin.GitRanger/Options/GeneralOptionsPage.cs
@@ -126,6 +126,15 @@ namespace CodingWithCalvin.GitRanger.Options
             set => _options.CompactMode = value;
         }
 
+        [Category("Display")]
+        [DisplayName("Inline Blame Display Mode")]
+        [Description("Controls when inline blame is shown: Always (all lines), CurrentLine (caret line only), or Hover (mouse hover only).")]
+        public InlineBlameMode InlineBlameDisplayMode
+        {
+            get => _options.InlineBlameDisplayMode;
+            set => _options.InlineBlameDisplayMode = value;
+        }
+
         // Gutter Settings
         [Category("Gutter")]
         [DisplayName("Gutter Width")]


### PR DESCRIPTION
## Summary
- Replaces the unimplemented `ShowOnHoverOnly` boolean with a new `InlineBlameDisplayMode` enum setting with three modes:
  - **Always** — show inline blame on all visible lines (existing default behavior)
  - **CurrentLine** — show inline blame only on the current caret line
  - **Hover** — show inline blame only when the mouse hovers over a line
- Exposes the new setting in Tools > Options > Git Ranger > General under the Display category

Resolves #74

## Test plan
- [ ] Verify **Always** mode shows blame on all lines (existing behavior unchanged)
- [ ] Verify **CurrentLine** mode shows blame only on the caret line, updating as the caret moves
- [ ] Verify **Hover** mode shows blame only on the line under the mouse cursor, clearing when the mouse leaves the editor
- [ ] Verify switching between modes in Tools > Options takes effect immediately
- [ ] Verify the setting persists across VS restarts