### PR TITLE
docs(readme): remove retired VS Marketplace shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,6 @@
   </a>
 </p>
 
-<p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-GitRanger">
-    <img src="https://img.shields.io/visual-studio-marketplace/v/CodingWithCalvin.VS-GitRanger?style=for-the-badge" alt="Marketplace Version">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-GitRanger">
-    <img src="https://img.shields.io/visual-studio-marketplace/i/CodingWithCalvin.VS-GitRanger?style=for-the-badge" alt="Marketplace Installations">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-GitRanger">
-    <img src="https://img.shields.io/visual-studio-marketplace/d/CodingWithCalvin.VS-GitRanger?style=for-the-badge" alt="Marketplace Downloads">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-GitRanger">
-    <img src="https://img.shields.io/visual-studio-marketplace/r/CodingWithCalvin.VS-GitRanger?style=for-the-badge" alt="Marketplace Rating">
-  </a>
-</p>
-
 ---
 
 ## ✨ Features


### PR DESCRIPTION
## Summary
- Removed retired shields.io Visual Studio Marketplace badges (Version, Installs, Downloads, Rating)
- The `visual-studio-marketplace` endpoint on shields.io has been retired and all badges show "Retired Badge"
- License and Build Status badges are unaffected and remain